### PR TITLE
Update all UKPersonalFinance wiki links

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
   <section id="phase-one" class="flow-container">
     <div class="flow-container__large-rectangle blue arrow-down">
       <p>
-        Know where your money is going by creating a <a href="https://www.reddit.com/r/ukpersonalfinance/wiki/budgeting" target="_blank" title="Creating a Budget">solid budget plan</a>
+        Know where your money is going by creating a <a href="https://ukpersonal.finance/budgeting" target="_blank" title="Creating a Budget">solid budget plan</a>
       </p>
     </div>
     <div class="flow-container__small-rectangle blue arrow-down">
@@ -252,7 +252,7 @@
   <section id="phase-eleven" class="flow-container">
     <div id="question-7" class="flow-container__large-rectangle red">
       <p>
-        Are the <a href="https://www.reddit.com/r/ukpersonalfinance/wiki/fees" target="_blank" title="Know your fees">total costs</a> of your employer pension ≤ 0.5%?
+        Are the <a href="https://ukpersonal.finance/fees" target="_blank" title="Know your fees">total costs</a> of your employer pension ≤ 0.5%?
       </p>
       <div class="choices">
         <div class="choice" onclick="hideLaterPhases(this, phaseEleven); showPhase(phaseThirteen)">Yes</div>

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
   <section class="overview">
     <div class="overview__step step-0">
       <p>
-        <strong>Step 0:</strong> <a href="https://www.reddit.com/r/ukpersonalfinance/wiki/budgeting" target="_blank" title="Creating a Budget">Budget</a> and reduce expenses, set realistic goals
+        <strong>Step 0:</strong> <a href="https://ukpersonal.finance/budgeting" target="_blank" title="Creating a Budget">Budget</a> and reduce expenses, set realistic goals
       </p>
     </div>
     <div class="overview__step step-1">
@@ -177,7 +177,7 @@
   <section id="phase-six" class="flow-container">
     <div class="flow-container__small-rectangle purple arrow-down">
       <p>
-        Consider saving via a Help to Buy: <a href="https://www.reddit.com/r/UKPersonalFinance/wiki/isa" title="ISA" target="_blank">ISA</a> / <a href="https://www.reddit.com/r/UKPersonalFinance/wiki/lisa" title="ISA" target="_blank">LISA</a>
+        Consider saving via a Help to Buy: <a href="https://ukpersonal.finance/isas" title="ISA" target="_blank">ISA</a> / <a href="https://ukpersonal.finance/isas/#LISA_Lifetime_ISA" title="ISA" target="_blank">LISA</a>
       </p>
     </div>
     <div class="flow-container__large-rectangle purple choice" onclick="hideLaterPhases(this, phaseSix); continueFlow(this, phaseSeven)">
@@ -264,7 +264,7 @@
   <section id="phase-twelve" class="flow-container">
     <div class="flow-container__small-rectangle red arrow-down">
       <p>
-        Open a SIPP and invest in low-cost <a href="https://www.reddit.com/r/UKPersonalFinance/wiki/globaltracker" title="Global Tracker" target="_blank">global index trackers</a>
+        Open a SIPP and invest in low-cost <a href="https://ukpersonal.finance/diy-global-tracker" title="Global Tracker" target="_blank">global index trackers</a>
       </p>
     </div>
    <div id="question-8" class="flow-container__large-rectangle red">
@@ -335,7 +335,7 @@
   <section id="phase-fifteen" class="flow-container">
     <div class="flow-container__small-rectangle blue arrow-down">
       <p>
-        S&amp;S ISA<br>Invest in low-cost <a href="https://www.reddit.com/r/UKPersonalFinance/wiki/globaltracker" title="Global Tracker" target="_blank">global index trackers</a>
+        S&amp;S ISA<br>Invest in low-cost <a href="https://ukpersonal.finance/diy-global-tracker" title="Global Tracker" target="_blank">global index trackers</a>
       </p>
     </div>
     <div class="flow-container__small-rectangle blue arrow-down">
@@ -350,7 +350,7 @@
     </div>
     <div class="flow-container__small-rectangle blue ">
       <p>
-        High Risk Investments to reduce tax: <a href="https://www.reddit.com/r/UKPersonalFinance/wiki/fundsfaq2" title="Funds FAQ" target="_blank">VCT / EIS / SEIS</a>
+        High Risk Investments to reduce tax: <a href="https://ukpersonal.finance/uk-funds-faq" title="Funds FAQ" target="_blank">VCT / EIS / SEIS</a>
       </p>
     </div>
   </section>
@@ -358,7 +358,7 @@
   <footer>
     <div class="disclaimer">
       <p>
-        The <a href="https://www.reddit.com/r/UKPersonalFinance/wiki/index" title="UKPersonalFinance Wiki" target="_blank">UKPersonalFinance Wiki</a> is a great place to start on your personal finance journey.
+        The <a href="https://ukpersonal.finance" title="UKPersonalFinance Wiki" target="_blank">UKPersonalFinance Wiki</a> is a great place to start on your personal finance journey.
       </p>
       <p>
         <em>This flowchart is for informational purposes only and should not be mistaken for, or replace, financial advice or guidance. The author assumes no liability for this. Always do your own research.</em>


### PR DESCRIPTION
The UKPersonalFinance wiki has moved to a off-reddit website. This PR updates all the links.

#4 which is open fixes the budgeting links, this fixes the rest of them. :)

Closes #3.